### PR TITLE
Makefile without submodule, Linux compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 *.exe
 *.dll
+*.so
 *.a
 *.o
 
+.vscode/
 compile_commands.json
 .cache/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.dll
 *.a
 *.o
+
+compile_commands.json
+.cache/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@
 .vscode/
 compile_commands.json
 .cache/
+
+test_c
+test_c.exe
+test_cpp
+test_cpp.exe

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,12 @@ $(sta_lib): $(c_sta_objects)
 	ar rcs $@ $^
 
 $(bin_dir)/$(dyn_dir)/%.o: %.c $(c_headers) $(bin_dir)/$(dyn_dir)
+ifeq ($(os), Windows_NT)
+	$(c_compiler) $(c_flags) -shared -c $< -o $@
+endif # Windows_NT
+ifeq ($(os), Linux)
 	$(c_compiler) $(c_flags) -fPIC -c $< -o $@
+endif # Linux
 
 $(dyn_lib): $(c_dyn_objects)
 	$(c_compiler) $(c_flags) -shared $^ -o $@ $(c_ldflags)

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ ifeq ($(os), Linux)
 	lib_ext = so
 endif # Linux
 
+
 sta_lib := $(bin_dir)/$(lib_name).a
 dyn_lib := $(bin_dir)/$(lib_name).$(lib_ext)
 
@@ -54,7 +55,13 @@ all:
 	@$(MAKE) libs
 	@$(MAKE) tests
 clean:
+ifeq ($(os), Windows_NT)
+	del \f $(wildcard *.$(project_ext) *.o *.a *.$(lib_ext))
+	rmdir $(wildcard $(bin_dir))
+endif # Windows_NT
+ifeq ($(os), Darwin)
 	rm -rf $(wildcard $(bin_dir) *.$(project_ext) *.o *.a *.$(lib_ext))
+endif # Linux
 libs:
 	@$(MAKE) static
 	@$(MAKE) dynamic

--- a/Makefile
+++ b/Makefile
@@ -1,111 +1,111 @@
 project_ext =
 
 
-tst_dir := test
-bin_dir := bin
-dyn_dir := dynamic
-sta_dir := static
-bin_dirs := $(bin_dir)/$(sta_dir) $(bin_dir)/$(dyn_dir) $(bin_dir)/$(tst_dir)
-
 # Compiler
+debug = # -g
+
 c_compiler := gcc
 c_std := -std=c11
 c_opt := -O2
 c_warn := -Wall
-c_ldflags := -lcrypto -lgdi32
-c_flags := $(c_std) $(c_opt) $(c_warn)
+c_shared := -shared
+c_flags := $(c_std) $(c_opt) $(c_warn) $(debug)
+c_ldflags := $(c_std) $(c_opt) $(c_warn) $(c_shared) $(debug)
+c_testflags := $(c_std) $(c_opt) $(c_warn) $(debug)
+c_libs := -lcrypto -lgdi32
 
 cpp_compiler := g++
 cpp_std := -std=c++11
 cpp_opt := -O2
 cpp_warn := -Wall
-cpp_ldflags := -lcrypto -lgdi32
-cpp_flags := $(cpp_std) $(cpp_opt) $(cpp_warn)
+cpp_shared := -shared
+cpp_flags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(debug)
+cpp_ldflags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(cpp_shared) $(debug)
+cpp_testflags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(debug)
+cpp_libs := -lcrypto -lgdi32
 
-# C files
+# Directories
+tst_dir := test
+bin_dir := bin
+dyn_dir := dynamic
+sta_dir := static
+bin_dirs := $(bin_dir)\$(sta_dir) $(bin_dir)\$(dyn_dir) $(bin_dir)\$(tst_dir)
+
+# C Files
 c_headers := $(wildcard *.h)
 c_sources := $(wildcard *.c)
-c_dyn_objects := $(patsubst %.c, $(bin_dir)/$(dyn_dir)/%.o, $(c_sources))
-c_sta_objects := $(patsubst %.c, $(bin_dir)/$(sta_dir)/%.o, $(c_sources))
+c_dyn_objects := $(patsubst %.c, $(bin_dir)\$(dyn_dir)\\%.o, $(c_sources))
+c_sta_objects := $(patsubst %.c, $(bin_dir)\$(sta_dir)\\%.o, $(c_sources))
 
 # Libraries
-lib_name := cotp
+lib_name := libcotp
 lib_ext =
 
-# Platform defines
-os := $(shell uname -s)
-ifeq ($(os), Windows_NT) 
+# Command Maps
+cmd_rm =
+cmd_ar = ar
+cmd_mkdir = mkdir
+
+# Platform Specific
+ifeq ($(OS), Windows_NT)
 	project_ext = .exe
 	lib_ext = dll
+	cmd_rm = del
+	cmd_mkdir +=
 endif # Windows_NT
-ifeq ($(os), Linux)
+ifeq ($(OS), Linux)
 	lib_ext = so
+	cmd_rm = rm
+	c_flags += -fPIC
+	cpp_flags += -fPIC
 endif # Linux
 
+sta_lib := $(bin_dir)\$(lib_name).a
+dyn_lib := $(bin_dir)\$(lib_name).$(lib_ext)
 
-sta_lib := $(bin_dir)/$(lib_name).a
-dyn_lib := $(bin_dir)/$(lib_name).$(lib_ext)
+test_c = $(bin_dir)\test_c$(project_ext)
+test_cpp = $(bin_dir)\test_c++$(project_ext)
 
-test_c = $(bin_dir)/test_c$(project_ext)
-test_cpp = $(bin_dir)/test_c++$(project_ext)
-
+###############################################################################
 
 .PHONY: all clean libs tests static dynamic test_c test_cpp
-all:
-	@$(MAKE) libs
-	@$(MAKE) tests
-clean:
-ifeq ($(os), Windows_NT)
-	del \f $(wildcard *.$(project_ext) *.o *.a *.$(lib_ext))
-	rmdir $(wildcard $(bin_dir))
-endif # Windows_NT
-ifeq ($(os), Darwin)
-	rm -rf $(wildcard $(bin_dir) *.$(project_ext) *.o *.a *.$(lib_ext))
-endif # Linux
-libs:
-	@$(MAKE) static
-	@$(MAKE) dynamic
-tests:
-	@$(MAKE) test_c
-	@$(MAKE) test_cpp
-static:
-	@echo "Building static library"
-	@$(MAKE) $(sta_lib)
-dynamic:
-	@echo "Building dynamic library"
-	@$(MAKE) $(dyn_lib)
-test_c:
-	@echo "Building test C application"
-	@$(MAKE) $(test_c)
-test_cpp:
-	@echo "Building test C++ application"
-	@$(MAKE) $(test_cpp)
 
-$(bin_dir)/$(sta_dir)/%.o: %.c $(c_headers) $(bin_dir)/$(sta_dir)
-	$(c_compiler) $(c_flags) -c $< -o $@
+all: libs tests
+
+clean:
+	$(cmd_rm) $(c_sta_objects) $(c_dyn_objects)
+
+libs: static dynamic
+
+tests: test_c test_cpp
+
+static: $(bin_dir)\$(sta_dir) $(sta_lib)
+
+dynamic: $(bin_dir)\$(dyn_dir) $(dyn_lib)
+
+test_c: $(test_c)
+
+test_cpp: $(test_cpp)
+
+###############################################################################
+
+$(bin_dir)\$(sta_dir)\\%.o: %.c $(c_headers) $(bin_dir)\$(sta_dir)
+	$(c_compiler) $(c_flags) -o $@ -c $<
 
 $(sta_lib): $(c_sta_objects)
-	ar rcs $@ $^
+	$(cmd_ar) rcs -o $@ $^
 
-$(bin_dir)/$(dyn_dir)/%.o: %.c $(c_headers) $(bin_dir)/$(dyn_dir)
-ifeq ($(os), Windows_NT)
-	$(c_compiler) $(c_flags) -shared -c $< -o $@
-endif # Windows_NT
-ifeq ($(os), Linux)
-	$(c_compiler) $(c_flags) -fPIC -c $< -o $@
-endif # Linux
+$(bin_dir)\$(dyn_dir)\\%.o: %.c $(c_headers) $(bin_dir)\$(dyn_dir)
+	$(c_compiler) $(c_flags) -o $@ -c $<
 
 $(dyn_lib): $(c_dyn_objects)
-	$(c_compiler) $(c_flags) -shared $^ -o $@ $(c_ldflags)
+	$(c_compiler) $(c_ldflags) -o $@ $^ $(c_libs)
 
-$(test_c): $(tst_dir)/main.c $(sta_lib)
-	$(c_compiler) $(c_flags) -c $< -o $@ -L$(bin_dir) $(c_ldflags)
+$(test_c): $(tst_dir)\main.c $(sta_lib)
+	$(c_compiler) $(c_testflags) -L$(bin_dir) -o $@ $< $(c_libs) $(sta_lib)
 
-$(test_cpp): $(tst_dir)/main.cpp $(sta_lib)
-	$(cpp_compiler) $(cpp_flags) -c $< -o $@ -L$(bin_dir) $(c_ldflags)
+$(test_cpp): $(tst_dir)\main.cpp $(sta_lib)
+	$(cpp_compiler) $(cpp_testflags) -L$(bin_dir) -o $@ $< $(cpp_libs) $(sta_lib)
 
-$(bin_dir):
-	-mkdir $@
-
-$(bin_dirs): $(bin_dir)
-	-mkdir $@
+$(bin_dir)\$(sta_dir) $(bin_dir)\$(dyn_dir):
+	-@mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,99 @@
+project_ext =
+
+
+tst_dir := test
+bin_dir := bin
+dyn_dir := dynamic
+sta_dir := static
+bin_dirs := $(bin_dir)/$(sta_dir) $(bin_dir)/$(dyn_dir) $(bin_dir)/$(tst_dir)
+
+# Compiler
+c_compiler := gcc
+c_std := -std=c11
+c_opt := -O2
+c_warn := -Wall
+c_ldflags := -lcrypto -lgdi32
+c_flags := $(c_std) $(c_opt) $(c_warn)
+
+cpp_compiler := g++
+cpp_std := -std=c++11
+cpp_opt := -O2
+cpp_warn := -Wall
+cpp_ldflags := -lcrypto -lgdi32
+cpp_flags := $(cpp_std) $(cpp_opt) $(cpp_warn)
+
+# C files
+c_headers := $(wildcard *.h)
+c_sources := $(wildcard *.c)
+c_dyn_objects := $(patsubst %.c, $(bin_dir)/$(dyn_dir)/%.o, $(c_sources))
+c_sta_objects := $(patsubst %.c, $(bin_dir)/$(sta_dir)/%.o, $(c_sources))
+
+# Libraries
+lib_name := cotp
+lib_ext =
+
+# Platform defines
+os := $(shell uname -s)
+ifeq ($(os), Windows_NT) 
+	project_ext = .exe
+	lib_ext = dll
+endif # Windows_NT
+ifeq ($(os), Linux)
+	lib_ext = so
+endif # Linux
+
+sta_lib := $(bin_dir)/$(lib_name).a
+dyn_lib := $(bin_dir)/$(lib_name).$(lib_ext)
+
+test_c = $(bin_dir)/test_c$(project_ext)
+test_cpp = $(bin_dir)/test_c++$(project_ext)
+
+
+.PHONY: all clean libs tests static dynamic test_c test_cpp
+all:
+	@$(MAKE) libs
+	@$(MAKE) tests
+clean:
+	rm -rf $(wildcard $(bin_dir) *.$(project_ext) *.o *.a *.$(lib_ext))
+libs:
+	@$(MAKE) static
+	@$(MAKE) dynamic
+tests:
+	@$(MAKE) test_c
+	@$(MAKE) test_cpp
+static:
+	@echo "Building static library"
+	@$(MAKE) $(sta_lib)
+dynamic:
+	@echo "Building dynamic library"
+	@$(MAKE) $(dyn_lib)
+test_c:
+	@echo "Building test C application"
+	@$(MAKE) $(test_c)
+test_cpp:
+	@echo "Building test C++ application"
+	@$(MAKE) $(test_cpp)
+
+$(bin_dir)/$(sta_dir)/%.o: %.c $(c_headers) $(bin_dir)/$(sta_dir)
+	$(c_compiler) $(c_flags) -c $< -o $@
+
+$(sta_lib): $(c_sta_objects)
+	ar rcs $@ $^
+
+$(bin_dir)/$(dyn_dir)/%.o: %.c $(c_headers) $(bin_dir)/$(dyn_dir)
+	$(c_compiler) $(c_flags) -fPIC -c $< -o $@
+
+$(dyn_lib): $(c_dyn_objects)
+	$(c_compiler) $(c_flags) -shared $^ -o $@ $(c_ldflags)
+
+$(test_c): $(tst_dir)/main.c $(sta_lib)
+	$(c_compiler) $(c_flags) -c $< -o $@ -L$(bin_dir) $(c_ldflags)
+
+$(test_cpp): $(tst_dir)/main.cpp $(sta_lib)
+	$(cpp_compiler) $(cpp_flags) -c $< -o $@ -L$(bin_dir) $(c_ldflags)
+
+$(bin_dir):
+	-mkdir $@
+
+$(bin_dirs): $(bin_dir)
+	-mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ sta_lib := $(lib_name).a
 dyn_lib := $(lib_name)$(lib_ext)
 
 test_c = test_c$(project_ext)
-test_cpp = test_c++$(project_ext)
+test_cpp = test_cpp$(project_ext)
 
 ###############################################################################
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ c_shared := -shared
 c_flags := $(c_std) $(c_opt) $(c_warn) $(debug)
 c_ldflags := $(c_std) $(c_opt) $(c_warn) $(c_shared) $(debug)
 c_testflags := $(c_std) $(c_opt) $(c_warn) $(debug)
-c_libs := -lcrypto -lgdi32
+c_libs := -lcrypto
 
 cpp_compiler := g++
 cpp_std := -std=c++11
@@ -22,20 +22,14 @@ cpp_shared := -shared
 cpp_flags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(debug)
 cpp_ldflags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(cpp_shared) $(debug)
 cpp_testflags := $(cpp_std) $(cpp_opt) $(cpp_warn) $(debug)
-cpp_libs := -lcrypto -lgdi32
-
-# Directories
-tst_dir := test
-bin_dir := bin
-dyn_dir := dynamic
-sta_dir := static
-bin_dirs := $(bin_dir)\$(sta_dir) $(bin_dir)\$(dyn_dir) $(bin_dir)\$(tst_dir)
+cpp_libs := -lcrypto
 
 # C Files
 c_headers := $(wildcard *.h)
 c_sources := $(wildcard *.c)
-c_dyn_objects := $(patsubst %.c, $(bin_dir)\$(dyn_dir)\\%.o, $(c_sources))
-c_sta_objects := $(patsubst %.c, $(bin_dir)\$(sta_dir)\\%.o, $(c_sources))
+c_objects := $(patsubst %.c, %.o, $(c_sources))
+c_test_sources := $(wildcard test/*.c)
+c_test_objects := $(pathsubst test/%.c, %.o, $(c_test_sources))
 
 # Libraries
 lib_name := libcotp
@@ -49,22 +43,21 @@ cmd_mkdir = mkdir
 # Platform Specific
 ifeq ($(OS), Windows_NT)
 	project_ext = .exe
-	lib_ext = dll
+	lib_ext = .dll
 	cmd_rm = del
 	cmd_mkdir +=
-endif # Windows_NT
-ifeq ($(OS), Linux)
-	lib_ext = so
+else
+	lib_ext = .so
 	cmd_rm = rm
 	c_flags += -fPIC
 	cpp_flags += -fPIC
 endif # Linux
 
-sta_lib := $(bin_dir)\$(lib_name).a
-dyn_lib := $(bin_dir)\$(lib_name).$(lib_ext)
+sta_lib := $(lib_name).a
+dyn_lib := $(lib_name)$(lib_ext)
 
-test_c = $(bin_dir)\test_c$(project_ext)
-test_cpp = $(bin_dir)\test_c++$(project_ext)
+test_c = test_c$(project_ext)
+test_cpp = test_c++$(project_ext)
 
 ###############################################################################
 
@@ -79,9 +72,9 @@ libs: static dynamic
 
 tests: test_c test_cpp
 
-static: $(bin_dir)\$(sta_dir) $(sta_lib)
+static: $(sta_lib)
 
-dynamic: $(bin_dir)\$(dyn_dir) $(dyn_lib)
+dynamic: $(dyn_lib)
 
 test_c: $(test_c)
 
@@ -89,14 +82,11 @@ test_cpp: $(test_cpp)
 
 ###############################################################################
 
-$(bin_dir)\$(sta_dir)\\%.o: %.c $(c_headers) $(bin_dir)\$(sta_dir)
+%.o: %.c $(c_headers)
 	$(c_compiler) $(c_flags) -o $@ -c $<
 
-$(sta_lib): $(c_sta_objects)
+$(sta_lib): $(c_objects)
 	$(cmd_ar) rcs -o $@ $^
-
-$(bin_dir)\$(dyn_dir)\\%.o: %.c $(c_headers) $(bin_dir)\$(dyn_dir)
-	$(c_compiler) $(c_flags) -o $@ -c $<
 
 $(dyn_lib): $(c_dyn_objects)
 	$(c_compiler) $(c_ldflags) -o $@ $^ $(c_libs)
@@ -106,6 +96,3 @@ $(test_c): $(tst_dir)\main.c $(sta_lib)
 
 $(test_cpp): $(tst_dir)\main.cpp $(sta_lib)
 	$(cpp_compiler) $(cpp_testflags) -L$(bin_dir) -o $@ $< $(cpp_libs) $(sta_lib)
-
-$(bin_dir)\$(sta_dir) $(bin_dir)\$(dyn_dir):
-	-@mkdir $@

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ c_headers := $(wildcard *.h)
 c_sources := $(wildcard *.c)
 c_objects := $(patsubst %.c, %.o, $(c_sources))
 c_test_sources := $(wildcard test/*.c)
+cpp_test_sources := $(wildcard test/*.cpp)
 c_test_objects := $(pathsubst test/%.c, %.o, $(c_test_sources))
 
 # Libraries
@@ -48,9 +49,10 @@ ifeq ($(OS), Windows_NT)
 	cmd_mkdir +=
 else
 	lib_ext = .so
-	cmd_rm = rm
+	cmd_rm = rm -f
 	c_flags += -fPIC
 	cpp_flags += -fPIC
+	c_libs += -lm
 endif # Linux
 
 sta_lib := $(lib_name).a
@@ -66,19 +68,19 @@ test_cpp = test_c++$(project_ext)
 all: libs tests
 
 clean:
-	$(cmd_rm) $(c_sta_objects) $(c_dyn_objects)
+	$(cmd_rm) $(c_objects) $(c_test_objects) $(sta_lib) $(dyn_lib) $(test_c) $(test_cpp)
 
 libs: static dynamic
 
-tests: test_c test_cpp
+tests: prog_test_c prog_test_cpp
 
 static: $(sta_lib)
 
 dynamic: $(dyn_lib)
 
-test_c: $(test_c)
+prog_test_c: $(test_c)
 
-test_cpp: $(test_cpp)
+prog_test_cpp: $(test_cpp)
 
 ###############################################################################
 
@@ -91,8 +93,8 @@ $(sta_lib): $(c_objects)
 $(dyn_lib): $(c_dyn_objects)
 	$(c_compiler) $(c_ldflags) -o $@ $^ $(c_libs)
 
-$(test_c): $(tst_dir)\main.c $(sta_lib)
-	$(c_compiler) $(c_testflags) -L$(bin_dir) -o $@ $< $(c_libs) $(sta_lib)
+$(test_c): $(c_test_sources) $(sta_lib)
+	$(c_compiler) $(c_testflags) -o $@ $< $(sta_lib) $(c_libs)
 
-$(test_cpp): $(tst_dir)\main.cpp $(sta_lib)
-	$(cpp_compiler) $(cpp_testflags) -L$(bin_dir) -o $@ $< $(cpp_libs) $(sta_lib)
+$(test_cpp): $(cpp_test_sources) $(sta_lib)
+	$(cpp_compiler) $(cpp_testflags) -o $@ $< $(sta_lib) $(cpp_libs)

--- a/build.bat
+++ b/build.bat
@@ -13,5 +13,5 @@ echo Building test C application
 gcc -O2 -Wall -L . -I . -o test_c.exe test/main.c -lcotp -lcrypto -lgdi32
 
 echo Building test C++ application
-g++ -O2 -Wall -L . -I . -o test_c++.exe test/main.cpp -lcotp -lcrypto -lgdi32
+g++ -O2 -Wall -L . -I . -o test_cpp.exe test/main.cpp -lcotp -lcrypto -lgdi32
 

--- a/build.bat
+++ b/build.bat
@@ -10,8 +10,8 @@ echo Building static library
 ar rcs -o libcotp.a cotp.o otpuri.o
 
 echo Building test C application
-gcc -O2 -Wall -L . -I . -o test_c.exe test/main.c -lcotp -lcrypto -lgdi32
+gcc -O2 -Wall -L . -I . -o test_c.exe test/main.c libcotp.a -lcrypto -lgdi32
 
 echo Building test C++ application
-g++ -O2 -Wall -L . -I . -o test_cpp.exe test/main.cpp -lcotp -lcrypto -lgdi32
+g++ -O2 -Wall -L . -I . -o test_cpp.exe test/main.cpp libcotp.a -lcrypto -lgdi32
 

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+echo "Compiling"
+gcc -O2 -Wall -shared -fPIC -c cotp.c otpuri.c
+
+echo "Building SO"
+gcc -O2 -Wall -shared -o libcotp.so cotp.o otpuri.o
+
+echo "Building static library"
+ar rcs -o libcotp.a cotp.o otpuri.o
+
+echo "Building test C application"
+gcc -O2 -Wall -L . -I . -o test_c test/main.c -lcotp -lcrypto -lm
+
+echo "Building test C++ application"
+g++ -O2 -Wall -L . -I . -o test_cpp test/main.cpp -lcotp -lcrypto
+

--- a/build.sh
+++ b/build.sh
@@ -10,8 +10,8 @@ echo "Building static library"
 ar rcs -o libcotp.a cotp.o otpuri.o
 
 echo "Building test C application"
-gcc -O2 -Wall -L . -I . -o test_c test/main.c -lcotp -lcrypto -lm
+gcc -O2 -Wall -L . -I . -o test_c test/main.c libcotp.a -lcrypto -lm
 
 echo "Building test C++ application"
-g++ -O2 -Wall -L . -I . -o test_cpp test/main.cpp -lcotp -lcrypto
+g++ -O2 -Wall -L . -I . -o test_cpp test/main.cpp libcotp.a -lcrypto
 

--- a/cotp.c
+++ b/cotp.c
@@ -443,7 +443,7 @@ int otp_generate(OTPData* data, uint64_t input, char* out_str)
 	
 	if(out_str != NULL)
 	{
-		sprintf(out_str, "%0*llu", data->digits, code);
+		sprintf(out_str, "%0*zu", data->digits, code);
 	}
 	
 	return OTP_OK;

--- a/otpuri.c
+++ b/otpuri.c
@@ -108,7 +108,7 @@ char* otpuri_build_uri(OTPData* data, const char* issuer, const char* name, cons
 		case HOTP:
 			otp_type = "hotp";
 			time = calloc(10 + 11 + 1, sizeof(char));
-			snprintf(time, 10 + 11 + 1, "%s%llu", "&counter=", data->count);
+			snprintf(time, 10 + 11 + 1, "%s%zu", "&counter=", data->count);
 			arg_len += strlen(time);
 			break;
 		default:

--- a/test/main.c
+++ b/test/main.c
@@ -131,10 +131,10 @@ int main(int argc, char** argv)
 	printf("hdata->method: `%u`\n", hdata->method);
 	printf("hdata->algo: `0x%p`\n", hdata->algo);
 	printf("hdata->base32_secret: `%s`\n", hdata->base32_secret);
-	printf("hdata->count: `%llu`\n", hdata->count);
+	printf("hdata->count: `%zu`\n", hdata->count);
 	printf("// hotp hdata //\n\n");
 	
-	printf("Current Time: `%llu`\n\n", get_current_time());
+	printf("Current Time: `%zu`\n\n", get_current_time());
 	
 	
 	


### PR DESCRIPTION
As discussed in #20, the goal is to bake all logic within the Makefile script (so no submodules like I had initially proposed). I rewrote the Makefile to provide the following:
- `make all` Creates all libraries and tests (static and dynamic for C and C++ respectively) 
- `make clean` Removes any generated files from the script
- `make libs` Creates both static and dynamic libraries
- `make static` Creates only the static library
- `make dynamic` Creates only the dynamic library
- `make tests` Creates both test executables for C and C++ (and it's prerequisites)
- `make test_c` Creates only the test executable for C (and it's prerequisites)
- `make test_cpp` Creates only the test executable for C++ (and it's prerequisites)

This script also doesn't use external code (e.g submodules).

- Closes #17
- Closes #20