### PR TITLE
Constant-time token comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ prog_test_cpp: libs $(test_cpp)
 $(sta_lib): $(c_objects)
 	$(cmd_ar) rcs -o $@ $^
 
-$(dyn_lib): $(c_dyn_objects)
+$(dyn_lib): $(c_objects)
 	$(c_compiler) $(c_ldflags) -o $@ $^ $(c_libs)
 
 $(test_c): $(c_test_sources) $(sta_lib)

--- a/cotp.c
+++ b/cotp.c
@@ -239,13 +239,12 @@ COTPRESULT totp_compare(OTPData* data, const char* key, int64_t offset, uint64_t
 	if (totp_at(data, for_time, offset, time_str) == 0)
 		return OTP_ERROR;
 	
-	int wins = 0;
+	int invalid = 0;
 	for (size_t i=0; i<data->digits; i++)
 	{
-		if (key[i] == time_str[i])
-			wins++;
+		invalid |=  key[i] != time_str[i];
 	}
-	if (wins != data->digits)
+	if (invalid != 0)
 		return OTP_ERROR;
 	
 	return OTP_OK;
@@ -390,16 +389,15 @@ int hotp_compare(OTPData* data, const char* key, uint64_t counter)
 	if (hotp_at(data, counter, cnt_str) == 0)
 		return OTP_ERROR;
 	
-	int wins = 0;
+	int invalid = 0;
 	for (size_t i=0; i<data->digits; i++)
 	{
-		if (key[i] == cnt_str[i])
-			wins++;
+		invalid |=  key[i] != cnt_str[i];
 	}
-	if (wins == data->digits)
-		return OTP_OK;
+	if (invalid != 0)
+		return OTP_ERROR;
 	
-	return OTP_ERROR;
+	return OTP_OK;
 }
 
 /*

--- a/cotp.c
+++ b/cotp.c
@@ -242,7 +242,7 @@ COTPRESULT totp_compare(OTPData* data, const char* key, int64_t offset, uint64_t
 	int invalid = 0;
 	for (size_t i=0; i<data->digits; i++)
 	{
-		invalid |=  key[i] != time_str[i];
+		invalid |=  key[i] ^ time_str[i];
 	}
 	if (invalid != 0)
 		return OTP_ERROR;
@@ -392,7 +392,7 @@ int hotp_compare(OTPData* data, const char* key, uint64_t counter)
 	int invalid = 0;
 	for (size_t i=0; i<data->digits; i++)
 	{
-		invalid |=  key[i] != cnt_str[i];
+		invalid |=  key[i] ^ cnt_str[i];
 	}
 	if (invalid != 0)
 		return OTP_ERROR;


### PR DESCRIPTION
Hi!

One of the authors of the CounterSEVeillance paper here.

Thank you for reaching out about feedback on the changes!

I checked your commits, and while the changes to the Base32 decoder fix the issue there, the comparison is still vulnerable:

![2025-01-14-171140_hyprshot](https://github.com/user-attachments/assets/b78250ad-0c35-40ce-af02-9a33e6b973a2)
![2025-01-14-163148_hyprshot](https://github.com/user-attachments/assets/05f8a8bb-aa89-423e-a8f3-28c961624cd1)

As you can see in the code from the disassembly, while the number of loop iterations is the same, there is still a branching instruction (`jnz`) that skips an instruction is not taken. This is detectable by both CounterSEVeillance, as well as a timing attack.

One possibility is to swap the `if` to bit arithmetics, which I did in the pull request.

With this code, the disassembly looks like this:

![2025-01-14-171838_hyprshot](https://github.com/user-attachments/assets/0a7fbcb3-0c69-4840-9b88-af54f5a6651d)

It does not contain any additional branching instructions anymore.

Another option would be to convert to integers first and then compare the tokens, which should also be a constant time operation.

I'd also like to add that avoiding timing side-channels is a non-trivial problem, and similar problems exist in many other projects.
The threat model shown in CounterSEVeillance, involving highly privileged attackers, is still relatively new, and it's not in scope for many projects.
This library was chosen as an example in the paper because it’s straightforward and easy to integrate, not because it is somehow worse than other projects.

Thank you for treating such an edge-case issue with such consideration.
If you have any further questions or comments, please let me know.

Cheers,
Hannes







