### PR TITLE
Miscellaneous patches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ test_cpp = test_cpp$(project_ext)
 
 ###############################################################################
 
-.PHONY: all clean libs tests static dynamic test_c test_cpp
+.PHONY: all clean libs tests static dynamic
 
 all: libs tests
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For linux users, you will want to install libcrypto via `sudo apt install libssl
 
 This library works with C++, but is targeted at C. I made a .hpp header that wraps the C functions, which I find gross. Feel free to clean it up and do a pull request. I do, however, have to recommend you use the .hpp header due to namespace flooding.
 
-See the [build.bat](build.bat) or [build.sh](build.sh) file for self-building guidance. If you don't want to use the .hpp C++ wrapper, you can `extern "C" #include "cotp.h"` which will flood your global space with the header file contents. We have a [Makefile](Makefile) for use: `make libs` for just the library or `make all` to also build the test examples.
+See the [build.bat](build.bat) or [build.sh](build.sh) file for self-building guidance. If you don't want to use the .hpp C++ wrapper, you can `#include "cotp.h"` which will flood your global space with the header file contents. We have a [Makefile](Makefile) for use: `make libs` for just the library or `make all` to also build the test examples.
 
 
 ## Usage

--- a/cotp.c
+++ b/cotp.c
@@ -140,20 +140,21 @@ COTPRESULT otp_byte_secret(OTPData* data, char* out_str) {
 	int valid = 1;
 	
 	for (size_t i = 0; i < num_blocks; i++) {
-		unsigned int block_values[8] = { 0 };
+		uint64_t block_value = 0;
 		
 		for (int j = 0; j < 8; j++) {
+			block_value <<= 5;
 			char c = data->base32_secret[i * 8 + j];
 			unsigned int value = (unsigned char) c < 256 ? OTP_DEFAULT_BASE32_OFFSETS[(unsigned char) c] : -1;
-			block_values[j] = value & 31;
+			block_value |= value & 31;
 			valid &= (value >= 0);
 		}
 		
-		out_str[i * 5] = (block_values[0] << 3) | (block_values[1] >> 2);
-		out_str[i * 5 + 1] = (block_values[1] << 6) | (block_values[2] << 1) | (block_values[3] >> 4);
-		out_str[i * 5 + 2] = (block_values[3] << 4) | (block_values[4] >> 1);
-		out_str[i * 5 + 3] = (block_values[4] << 7) | (block_values[5] << 2) | (block_values[6] >> 3);
-		out_str[i * 5 + 4] = (block_values[6] << 5) | block_values[7];
+		out_str[i * 5 + 0] = block_value >> 32;
+		out_str[i * 5 + 1] = block_value >> 24;
+		out_str[i * 5 + 2] = block_value >> 16;
+		out_str[i * 5 + 3] = block_value >>  8;
+		out_str[i * 5 + 4] = block_value >>  0;
 	}
 
 	return valid ? OTP_OK : OTP_ERROR;

--- a/cotp.c
+++ b/cotp.c
@@ -459,10 +459,12 @@ COTPRESULT otp_generate(OTPData* data, uint64_t input, char* out_str)
 		return OTP_ERROR;
 	
 	int hmac_len = (*(data->algo))(byte_secret, bs_len, byte_string, hmac);
-	if (hmac_len == 0)
+	if (hmac_len < 1 || hmac_len > 64)
 		return OTP_ERROR;
 	
-	uint64_t offset = (hmac[hmac_len - 1] & 0xF);
+	size_t offset = (hmac[hmac_len - 1] & 0xF);
+	if (offset + 3 >= hmac_len)
+		return OTP_ERROR;
 	uint64_t code =
 		(((hmac[offset] & 0x7F) << 24)
 		| ((hmac[offset+1] & 0xFF) << 16)

--- a/cotp.c
+++ b/cotp.c
@@ -51,7 +51,7 @@ OTPData* otp_new(OTPData* data, const char* base32_secret, COTP_ALGO algo, uint3
 	data->algo = algo;
 	data->time = NULL;
 	
-	data->base32_secret = &base32_secret[0];
+	data->base32_secret = base32_secret;
 	
 	return data;
 }
@@ -454,8 +454,8 @@ COTPRESULT otp_generate(OTPData* data, uint64_t input, char* out_str)
 	char hmac[64+1];
 	memset(hmac, 0, 64+1);
 	
-	if (otp_num_to_bytestring(input, byte_string) == 0
-			|| otp_byte_secret(data, byte_secret) == 0)
+	if (otp_num_to_bytestring(input, byte_string) != OTP_OK
+			|| otp_byte_secret(data, byte_secret) != OTP_OK)
 		return OTP_ERROR;
 	
 	int hmac_len = (*(data->algo))(byte_secret, bs_len, byte_string, hmac);

--- a/cotp.c
+++ b/cotp.c
@@ -470,7 +470,7 @@ COTPRESULT otp_generate(OTPData* data, uint64_t input, char* out_str)
 		| ((hmac[offset+3] & 0xFF)));
 	
 	static const uint64_t POWERS[] = { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000 };
-	code %= (uint64_t) POWERS[data->digits];
+	code %= POWERS[data->digits];
 	
 	sprintf(out_str, "%0*" PRIu64, data->digits, code);
 	

--- a/cotp.h
+++ b/cotp.h
@@ -77,7 +77,7 @@ typedef int (*COTP_ALGO)(const char* key, int key_length, const char* input, cha
 /*
 	Must return the current time in seconds.
 */
-typedef uint64_t (*COTP_TIME)();
+typedef uint64_t (*COTP_TIME)(void);
 
 
 /*

--- a/cotp.h
+++ b/cotp.h
@@ -3,6 +3,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
 
 // OTPRESULT can either be 1 (success) or 0 (error)
 typedef int COTPRESULT;
@@ -135,3 +138,7 @@ uint64_t totp_timecode(OTPData* data, uint64_t for_time);
 COTPRESULT hotp_compare(OTPData* data, const char* key, uint64_t counter);
 COTPRESULT hotp_at(OTPData* data, uint64_t counter, char* out_str);
 COTPRESULT hotp_next(OTPData* data, char* out_str);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/cotp.hpp
+++ b/cotp.hpp
@@ -3,11 +3,8 @@
 
 #if defined(__cplusplus)
 
-extern "C"
-{
-	#include "cotp.h"
-	#include "otpuri.h"
-}
+#include "cotp.h"
+#include "otpuri.h"
 
 #include <cstdint>
 

--- a/otpuri.h
+++ b/otpuri.h
@@ -2,6 +2,14 @@
 
 #include "cotp.h"
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 size_t otpuri_strlen(OTPData* data, const char* issuer, const char* name, const char* digest);
 COTPRESULT otpuri_encode_url(const char* data, size_t length, char* output);
 COTPRESULT otpuri_build_uri(OTPData* data, const char* issuer, const char* name, const char* digest, char* output);
+
+#if defined(__cplusplus)
+}
+#endif

--- a/test/main.c
+++ b/test/main.c
@@ -3,6 +3,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdbool.h>
 #include <string.h>
 #include <time.h>
 
@@ -102,6 +103,8 @@ int main(int argc, char** argv)
 	
 	// Base32 secret to utilize with padding
 	const char BASE32_SECRET_PADDING[] = "ORSXG5BRGIZXIZLTOQ2DKNRXHA4XIZLTOQYQ====";
+
+	bool success = true;
 	
 	OTPData odata1;
 	memset(&odata1, 0, sizeof(OTPData));
@@ -213,6 +216,7 @@ int main(int argc, char** argv)
 	
 	int random_otp_err = otp_random_base32(base32_len, base32_new_secret);
 	printf("Random Generated BASE32 Secret pass=1: `%s` `%d`\n", base32_new_secret, random_otp_err);
+	success = success && (random_otp_err == 1);
 	
 	puts(""); // line break for readability
 	
@@ -238,6 +242,7 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	printf("totp_now() pass=1: `%s` `%d`\n", tcode, totp_err_1);
+	success = success && (totp_err_1 == 1);
 	
 	// totp_at
 	char tcode2[DIGITS+1];
@@ -250,15 +255,18 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	printf("totp_at(0, 0) pass=1: `%s` `%d`\n", tcode2, totp_err_2);
+	success = success && (totp_err_2 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, this code is for a timeblock far into the past/future
 	int tv1 = totp_verify(tdata, "358892", get_current_time(), 4);
 	printf("TOTP Verification 1 pass=false: `%s`\n", tv1 == 0 ? "false" : "true");
+	success = success && (tv1 == 0);
 	
 	// Will succeed, timeblock 0 for JBSWY3DPEHPK3PXP == 282760
 	int tv2 = totp_verify(tdata, "282760", 0, 4);
 	printf("TOTP Verification 2 pass=true: `%s`\n", tv2 == 0 ? "false" : "true");
+	success = success && (tv2 != 0);
 	
 	puts(""); // line break for readability
 	
@@ -284,6 +292,7 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	printf("totp_now() (padding) pass=1: `%s` `%d`\n", tcode3, totp_err_3);
+	success = success && (totp_err_3 == 1);
 	
 	// totp_at
 	char tcode4[DIGITS+1];
@@ -296,15 +305,18 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	printf("totp_at(0, 0) (padding) pass=1: `%s` `%d`\n", tcode4, totp_err_4);
+	success = success && (totp_err_4 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, this code is for a timeblock far into the past/future
 	int tv3 = totp_verify(tdata_padding, "122924", get_current_time(), 4);
 	printf("TOTP Verification 1 (padding) pass=false: `%s`\n", tv3 == 0 ? "false" : "true");
+	success = success && (tv3 == 0);
 	
 	// Will succeed, timeblock 0 for 'ORSXG5BRGIZXIZLTOQ2DKNRXHA4XIZLTOQYQ====' == 570783
 	int tv4 = totp_verify(tdata_padding, "570783", 0, 4);
 	printf("TOTP Verification 2 (padding) pass=true: `%s`\n", tv4 == 0 ? "false" : "true");
+	success = success && (tv4 != 0);
 	
 	puts(""); // line break for readability
 	
@@ -329,16 +341,19 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	printf("hotp_at(1) pass=1: `%s` `%d`\n", hcode, hotp_err_1);
+	success = success && (hotp_err_1 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, 1 for JBSWY3DPEHPK3PXP == 996554
 	int hv1 = hotp_compare(hdata, "996555", 1);
 	printf("HOTP Verification 1 pass=false: `%s`\n", hv1 == 0 ? "false" : "true");
+	success = success && (hv1 == 0);
 	
 	// Will succeed, 1 for JBSWY3DPEHPK3PXP == 996554
 	int hv2 = hotp_compare(hdata, "996554", 1);
 	printf("HOTP Verification 2 pass=true: `%s`\n", hv2 == 0 ? "false" : "true");
+	success = success && (hv2 != 0);
 	
-	return EXIT_SUCCESS;
+	return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/test/main.c
+++ b/test/main.c
@@ -72,7 +72,7 @@ int hmac_algo_sha512(const char* byte_secret, int key_length, const char* byte_s
 	return result == 0 ? 0 : len;
 }
 
-static uint64_t get_current_time()
+static uint64_t get_current_time(void)
 {
 	uint64_t seconds;
 	

--- a/test/main.c
+++ b/test/main.c
@@ -1,15 +1,10 @@
+#define _TIME_BITS 64
+#define _FILE_OFFSET_BITS 64
 
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-
-#if defined(_WIN32)
-#	include <sysinfoapi.h>
-#elif defined(__linux__)
-#	include <sys/time.h>
-#else
-#	error "OS not supported."
-#endif
+#include <time.h>
 
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
@@ -77,27 +72,17 @@ int hmac_algo_sha512(const char* byte_secret, int key_length, const char* byte_s
 	return result == 0 ? 0 : len;
 }
 
-uint64_t get_current_time()
+static uint64_t get_current_time()
 {
-	uint64_t milliseconds = 0;
+	uint64_t seconds;
 	
 #if defined(_WIN32)
-	FILETIME fileTime;
-	GetSystemTimeAsFileTime(&fileTime);
-	
-	ULARGE_INTEGER largeInteger;
-	largeInteger.LowPart = fileTime.dwLowDateTime;
-	largeInteger.HighPart = fileTime.dwHighDateTime;
-	
-	milliseconds = (largeInteger.QuadPart - 116444736000000000ULL) / 10000000ULL;
-#elif defined(__linux__)
-	struct timeval sys_time;
-	gettimeofday(&sys_time, NULL);
-	
-	milliseconds = sys_time.tv_sec;
+	seconds = _time64(NULL);
+#else
+	seconds = time(NULL);
 #endif
 	
-	return milliseconds;
+	return seconds;
 }
 
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -105,6 +105,8 @@ int main(int argc, char** argv)
 	// Base32 secret to utilize with padding
 	const char BASE32_SECRET_PADDING[] = "ORSXG5BRGIZXIZLTOQ2DKNRXHA4XIZLTOQYQ====";
 	
+	bool success = true;
+	
 	OTPData odata1;
 	memset(&odata1, 0, sizeof(OTPData));
 	
@@ -222,6 +224,7 @@ int main(int argc, char** argv)
 	
 	int random_otp_err = OTP::random_base32(base32_len, base32_new_secret);
 	cout << "Random Generated BASE32 Secret pass=1: `" << base32_new_secret << "` `" << random_otp_err << "`" << endl;
+	success = success && (random_otp_err == 1);
 	
 	cout << endl; // line break for readability
 	
@@ -247,6 +250,7 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	cout << "totp_now() (padding) pass=1: `" << tcode << "` `" << totp_err_1 << "`" << endl;
+	success = success && (totp_err_1 == 1);
 	
 	// totp_at
 	char tcode2[DIGITS+1];
@@ -259,15 +263,18 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	cout << "totp_at(0, 0) (padding) pass=1: `" << tcode2 << "` `" << totp_err_2 << "`" << endl;
+	success = success && (totp_err_2 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, this code is for a timeblock far into the past/future
 	int tv1 = tdata.verify("358892", get_current_time(), 4);
 	cout << "TOTP Verification 1 (padding) pass=false: `" << (tv1 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (tv1 == 0);
 	
 	// Will succeed, timeblock 0 for JBSWY3DPEHPK3PXP == 282760
 	int tv2 = tdata.verify("282760", 0, 4);
 	cout << "TOTP Verification 2 (padding) pass=true: `" << (tv2 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (tv2 != 0);
 	
 	cout << endl; // line break for readability
 	
@@ -293,6 +300,7 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	cout << "totp_now() pass=1: `" << tcode3 << "` `" << totp_err_3 << "`" << endl;
+	success = success && (totp_err_3 == 1);
 	
 	// totp_at
 	char tcode4[DIGITS+1];
@@ -305,15 +313,18 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	cout << "totp_at(0, 0) pass=1: `" << tcode4 << "` `" << totp_err_4 << "`" << endl;
+	success = success && (totp_err_4 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, this code is for a timeblock far into the past/future
 	int tv3 = tdata_padding.verify("358892", get_current_time(), 4);
 	cout << "TOTP Verification 1 pass=false: `" << (tv3 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (tv3 == 0);
 	
 	// Will succeed, timeblock 0 for 'ORSXG5BRGIZXIZLTOQ2DKNRXHA4XIZLTOQYQ====' == 570783
 	int tv4 = tdata_padding.verify("570783", 0, 4);
 	cout << "TOTP Verification 2 pass=true: `" << (tv4 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (tv4 != 0);
 	
 	cout << endl; // line break for readability
 	
@@ -337,16 +348,19 @@ int main(int argc, char** argv)
 		return EXIT_FAILURE;
 	}
 	cout << "hotp_at(1) pass=1: `" << hcode << "`" << " `" << hotp_err_1 << "`" << endl;
+	success = success && (hotp_err_1 == 1);
 	
 	// Do a verification for a hardcoded code
 	// Won't succeed, 1 for JBSWY3DPEHPK3PXP == 996554
 	int hv1 = hdata.compare("996555", 1);
 	cout << "HOTP Verification 1 pass=false: `" << (hv1 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (hv1 == 0);
 	
 	// Will succeed, 1 for JBSWY3DPEHPK3PXP == 996554
 	int hv2 = hdata.compare("996554", 1);
 	cout << "HOTP Verification 2 pass=true: `" << (hv2 == 0 ? "false" : "true") << "`" << endl;
+	success = success && (hv2 != 0);
 	
-	return EXIT_SUCCESS;
+	return success ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -77,7 +77,6 @@ int hmac_algo_sha512(const char* byte_secret, int key_length, const char* byte_s
 	return result == 0 ? 0 : len;
 }
 
-// TODO: use a secure random generator
 uint64_t get_current_time()
 {
 	using namespace std::chrono;


### PR DESCRIPTION
A bunch of not so related changes, mostly minor.

**Remove misleading comment**
 
`get_current_time()` is not used to seed random number generators.
    
**Use time() to compute epoch time**

Simplify `get_current_time()` function as `time()` is common to more systems.
Also is more portable allowing to support more systems.

**Wrap C function for C++ in headers**

This allows to include just C headers in C++ code.
This format is also more common.

**Remove useless cast**
    
`POWERS` items are already uint64_t.

**Avoid hmac overflows in otp_generate**

Returns OTP_ERROR instead.

**Minor style changes**

Use mnemonics to test `otp_num_to_bytestring` results.
Simply copy the pointer for `base32_secret` string.

**Simplify otp_byte_secret computation**

Avoids the complex shifts to compute output.

**Do not rebuild tests if not changed**

`test_c` and `test_cpp` are real target, so remove them from the phony list otherwise they get rebuild even if not changed.

**Use proper C declaration for functions not taking arguments**

For historic reasons without anything the functions are allows to take any argument, better state that there are no argument.

**Make test.c a proper test**

Returns success or error based on tests.
